### PR TITLE
beta

### DIFF
--- a/src/api/modules/charge.module.ts
+++ b/src/api/modules/charge.module.ts
@@ -133,6 +133,11 @@ export async function listCharges(
         for (const filter of filters) {
           if (typeof filter !== 'object' || filter === null) continue;
           const value = filter as Record<string, unknown>;
+          const typeId = Number(value['charges.type_id'] ?? value.type_id);
+          if (Number.isFinite(typeId)) {
+            query = query.where('charges.type_id', '=', typeId);
+            count = count.where('charges.type_id', '=', typeId);
+          }
           if (
             typeof value.bestbefore === 'object' &&
             value.bestbefore !== null

--- a/src/api/modules/queen.module.ts
+++ b/src/api/modules/queen.module.ts
@@ -138,13 +138,28 @@ export async function listQueens(
               .where('queens.date', '>=', new Date(range.from))
               .where('queens.date', '<=', new Date(range.to));
           }
+          const matingId = Number(value['queens.mating_id']);
+          if (Number.isFinite(matingId)) {
+            query = query.where('queens.mating_id', '=', matingId);
+            count = count.where('queens.mating_id', '=', matingId);
+          }
+          const raceId = Number(value['queens.race_id']);
+          if (Number.isFinite(raceId)) {
+            query = query.where('queens.race_id', '=', raceId);
+            count = count.where('queens.race_id', '=', raceId);
+          }
+          const apiaryId = Number(value['hive_location.apiary_id']);
+          if (Number.isFinite(apiaryId)) {
+            query = query.where('hives_locations.apiary_id', '=', apiaryId);
+            count = count.where('hives_locations.apiary_id', '=', apiaryId);
+          }
           const hive = value['queens.hive_id'];
           if (hive === 'empty') {
             query = query.where('hives_locations.hive_id', 'is', null);
             count = count.where('hives_locations.hive_id', 'is', null);
-          } else if (typeof hive === 'number') {
-            query = query.where('queens.hive_id', '=', hive);
-            count = count.where('queens.hive_id', '=', hive);
+          } else if (Number.isFinite(Number(hive))) {
+            query = query.where('queens.hive_id', '=', Number(hive));
+            count = count.where('queens.hive_id', '=', Number(hive));
           }
         }
       }
@@ -251,13 +266,28 @@ export async function listQueenStats(
               .where('queen_durations.move_date', '>=', new Date(range.from))
               .where('queen_durations.move_date', '<=', new Date(range.to));
           }
+          const matingId = Number(value['queens.mating_id']);
+          if (Number.isFinite(matingId)) {
+            query = query.where('queens.mating_id', '=', matingId);
+            count = count.where('queens.mating_id', '=', matingId);
+          }
+          const raceId = Number(value['queens.race_id']);
+          if (Number.isFinite(raceId)) {
+            query = query.where('queens.race_id', '=', raceId);
+            count = count.where('queens.race_id', '=', raceId);
+          }
+          const apiaryId = Number(value['hive_location.apiary_id']);
+          if (Number.isFinite(apiaryId)) {
+            query = query.where('hives_locations.apiary_id', '=', apiaryId);
+            count = count.where('hives_locations.apiary_id', '=', apiaryId);
+          }
           const hive = value['queens.hive_id'];
           if (hive === 'empty') {
             query = query.where('hives_locations.hive_id', 'is', null);
             count = count.where('hives_locations.hive_id', 'is', null);
-          } else if (typeof hive === 'number') {
-            query = query.where('queen_durations.hive_id', '=', hive);
-            count = count.where('queen_durations.hive_id', '=', hive);
+          } else if (Number.isFinite(Number(hive))) {
+            query = query.where('queen_durations.hive_id', '=', Number(hive));
+            count = count.where('queen_durations.hive_id', '=', Number(hive));
           }
         }
       }

--- a/src/api/modules/statistic.module.ts
+++ b/src/api/modules/statistic.module.ts
@@ -76,6 +76,13 @@ function parseStatisticFilters(
       ) {
         return [{ kind: 'year', value: Number(candidate.year) }];
       }
+      // Deprecated compatibility for legacy clients. Use hive_id_array instead.
+      if (
+        candidate.hive_id !== undefined &&
+        Number.isFinite(Number(candidate.hive_id))
+      ) {
+        return [{ kind: 'hiveInclude', value: [Number(candidate.hive_id)] }];
+      }
       const typeValue = task ? candidate[`${task}s.type_id`] : undefined;
       if (typeValue !== undefined && Number.isFinite(Number(typeValue))) {
         return [{ kind: 'type', value: Number(typeValue) }];
@@ -641,6 +648,10 @@ export async function listHiveRatingStatistics(
       base = base
         .where('checkup.date', '>=', new Date(`${filter.value}-01-01`))
         .where('checkup.date', '<=', new Date(`${filter.value}-12-31`));
+    } else if (filter.kind === 'hiveInclude') {
+      base = base.where('checkup.hive_id', 'in', filter.value);
+    } else if (filter.kind === 'hiveExclude') {
+      base = base.where('checkup.hive_id', 'not in', filter.value);
     }
   }
   const search = input.q === undefined ? '' : String(input.q).trim();

--- a/src/api/schemas/statistic.schema.ts
+++ b/src/api/schemas/statistic.schema.ts
@@ -75,7 +75,7 @@ const typeResponseSchema = z
   })
   .nullable();
 
-export const taskStatisticResponseSchema = z.looseObject({
+export const taskStatisticResponseSchema = z.object({
   year: z.number().nullable().optional(),
   hive_id: z.number().nullable().optional(),
   hive_count: numericResultSchema.optional(),

--- a/test/e2e/12-charge-routes.e2e.test.ts
+++ b/test/e2e/12-charge-routes.e2e.test.ts
@@ -81,6 +81,15 @@ describe('charge routes', () => {
       expect(res.body.total).toBeTypeOf('number');
     });
 
+    it('filters charges by type', async () => {
+      const res = await doQueryRequest(agent, route, null, accessToken, {
+        filters: JSON.stringify([{ 'charges.type_id': 999_999 }]),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.body.results).toEqual([]);
+      expect(res.body.total).toBe(0);
+    });
+
     it('operations enforce company isolation', async () => {
       const db = KyselyServer.getInstance().db;
       expect(await getChargesByIds(db, 999_999, [insertId])).toEqual([]);

--- a/test/e2e/19-queen-routes.e2e.test.ts
+++ b/test/e2e/19-queen-routes.e2e.test.ts
@@ -79,6 +79,22 @@ describe('queen routes', () => {
       expect(res.body.total).toBeTypeOf('number');
     });
 
+    it('applies all queen table filters', async () => {
+      for (const filter of [
+        { 'queens.mating_id': 999_999 },
+        { 'queens.race_id': 999_999 },
+        { 'queens.hive_id': '999999' },
+        { 'hive_location.apiary_id': 999_999 },
+      ]) {
+        const res = await doQueryRequest(agent, route, null, accessToken, {
+          filters: JSON.stringify([filter]),
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.body.results).toEqual([]);
+        expect(res.body.total).toBe(0);
+      }
+    });
+
     it('operations enforce company isolation', async () => {
       const db = KyselyServer.getInstance().db;
       expect(await getQueensByIds(db, 999_999, [insertId])).toEqual([]);
@@ -133,6 +149,26 @@ describe('queen routes', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results).toBeInstanceOf(Array);
       expect(res.body.total).toBeTypeOf('number');
+    });
+
+    it('applies all queen statistic filters', async () => {
+      for (const filter of [
+        { 'queens.mating_id': 999_999 },
+        { 'queens.race_id': 999_999 },
+        { 'queens.hive_id': '999999' },
+        { 'hive_location.apiary_id': 999_999 },
+      ]) {
+        const res = await doQueryRequest(
+          agent,
+          `${route}/stats`,
+          null,
+          accessToken,
+          { filters: JSON.stringify([filter]) },
+        );
+        expect(res.statusCode).toBe(200);
+        expect(res.body.results).toEqual([]);
+        expect(res.body.total).toBe(0);
+      }
     });
   });
 

--- a/test/e2e/26-statistic-routes.e2e.test.ts
+++ b/test/e2e/26-statistic-routes.e2e.test.ts
@@ -127,6 +127,100 @@ describe('statistic routes', () => {
     });
   }
 
+  it('filters hive statistics by scalar and array hive IDs', async () => {
+    const db = KyselyServer.getInstance().db;
+    const firstHive = await db
+      .insertInto('hives')
+      .values({ name: 'stat-filter-a', user_id: 1, deleted: false })
+      .executeTakeFirstOrThrow();
+    const secondHive = await db
+      .insertInto('hives')
+      .values({ name: 'stat-filter-b', user_id: 1, deleted: false })
+      .executeTakeFirstOrThrow();
+    const firstHiveId = Number(firstHive.insertId);
+    const secondHiveId = Number(secondHive.insertId);
+    const taskRows = [
+      {
+        amount: '10',
+        date: new Date('2025-07-01'),
+        deleted: false,
+        hive_id: firstHiveId,
+        user_id: 1,
+      },
+      {
+        amount: '20',
+        date: new Date('2025-07-01'),
+        deleted: false,
+        hive_id: secondHiveId,
+        user_id: 1,
+      },
+    ];
+    await db.insertInto('harvests').values(taskRows).execute();
+    await db.insertInto('feeds').values(taskRows).execute();
+    await db.insertInto('treatments').values(taskRows).execute();
+    await db
+      .insertInto('checkups')
+      .values(
+        taskRows.map(({ date, deleted, hive_id, user_id }) => ({
+          brood: 1,
+          calm_comb: 1,
+          comb: 1,
+          pollen: 1,
+          strong: 1,
+          swarm: 1,
+          temper: 1,
+          varroa: 1,
+          date,
+          deleted,
+          hive_id,
+          user_id,
+        })),
+      )
+      .execute();
+
+    try {
+      for (const task of ['harvest', 'feed', 'treatment', 'rating']) {
+        for (const filter of [
+          { hive_id: String(firstHiveId) },
+          { hive_id_array: [firstHiveId] },
+          { hive_id_array_exclude: [secondHiveId] },
+        ]) {
+          const filtered = await doQueryRequest(
+            agent,
+            `${route}/${task}/hive`,
+            null,
+            null,
+            {
+              filters: JSON.stringify([filter]),
+              limit: 10_000,
+              groupByType: true,
+            },
+          );
+          expect(filtered.statusCode).toBe(200);
+          expect(filtered.body.results).toHaveLength(1);
+          expect(filtered.body.results[0].hive_id).toBe(firstHiveId);
+          expect(filtered.body.total).toBe(1);
+        }
+      }
+    } finally {
+      for (const table of [
+        'harvests',
+        'feeds',
+        'treatments',
+        'checkups',
+      ] as const) {
+        await db
+          .deleteFrom(table)
+          .where('hive_id', 'in', [firstHiveId, secondHiveId])
+          .execute();
+      }
+      await db
+        .deleteFrom('hives')
+        .where('id', 'in', [firstHiveId, secondHiveId])
+        .execute();
+    }
+  });
+
   it('returns rating and Varroa statistics', async () => {
     const rating = await doQueryRequest(
       agent,


### PR DESCRIPTION
Restore hive, queen, and charge filters dropped during Kysely migrations. Keep scalar hive IDs as deprecated compatibility.